### PR TITLE
Search folders for envelopes

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -716,11 +716,6 @@ module DocusignRest
       response = http.request(request)
       parsed_response = JSON.parse(response.body)
     end
-
-    # Calls the proper api based on the configuration setup.
-    def api
-      "DocusignRest::Client::#{self.api_version.capitalize}".constantize
-    end
   end
 
 end


### PR DESCRIPTION
This method adds the ability to search by folder through all of your docusign envelopes to retrieve the envelope data. 

This method was needed as we have a lot of documents but weren't storing the envelope id, so we needed to search through the folders to find the envelope matching the criteria. 

This method allowed me to accomplish that.
