### PR TITLE
Add get_envelope_statuses/documents

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -787,6 +787,32 @@ module DocusignRest
       JSON.parse(response.body)
     end
 
+    # Public retrieves the statuses of envelopes matching the given query
+    #
+    # from_date      - Docusign formatted Date/DateTime. Only return items after this date.
+    #
+    # to_date        - Docusign formatted Date/DateTime. Only return items up to this date.
+    #                  Defaults to the time of the call.
+    #
+    # from_to_status - The status of the envelope checked for in the from_date - to_date period.
+    #                  Defaults to 'changed'
+    #
+    # status         - The current status of the envelope. Defaults to any status.
+    #
+    # Returns an array of hashes containing envelope statuses, ids, and similar information.
+    def get_envelope_statuses(options={})
+      content_type = { 'Content-Type' => 'application/json' }
+      content_type.merge(options[:headers]) if options[:headers]
+
+      query_params = options.slice(:from_date, :to_date, :from_to_status, :status)
+      uri = build_uri("/accounts/#{acct_id}/envelopes?#{query_params.to_query}")
+
+      http     = initialize_net_http_ssl(uri)
+      request  = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
+      response = http.request(request)
+
+      JSON.parse(response.body)
+    end
 
     # Public retrieves the attached file from a given envelope
     #
@@ -828,6 +854,23 @@ module DocusignRest
       end
     end
 
+    # Public retrieves the document infos from a given envelope
+    #
+    # envelope_id - ID of the envelope from which document infos are to be retrieved
+    #
+    # Returns a hash containing the envelopeId and the envelopeDocuments array
+    def get_documents_from_envelope(options={})
+      content_type = { 'Content-Type' => 'application/json' }
+      content_type.merge(options[:headers]) if options[:headers]
+
+      uri = build_uri("/accounts/#{acct_id}/envelopes/#{options[:envelope_id]}/documents")
+
+      http     = initialize_net_http_ssl(uri)
+      request  = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
+      response = http.request(request)
+
+      JSON.parse(response.body)
+    end
 
     # Public retrieves the envelope(s) from a specific folder based on search params.
     #

--- a/lib/multipart_post/parts.rb
+++ b/lib/multipart_post/parts.rb
@@ -3,7 +3,7 @@ require 'parts'
 
 Parts::ParamPart.class_eval do
   def build_part(boundary, name, value)
-    part = "\r\n" #Add a leading carriage return line feed (not sure why DocuSign requires this)
+    part = ""
     part << "--#{boundary}\r\n"
     part << "Content-Type: application/json\r\n" #Add the content type which isn't present in the multipart-post gem, but DocuSign requires
     part << "Content-Disposition: form-data; name=\"#{name.to_s}\"\r\n"

--- a/test/docusign_rest/client_test.rb
+++ b/test/docusign_rest/client_test.rb
@@ -108,12 +108,12 @@ describe DocusignRest::Client do
               ],
               list_tabs: [
                 {
-                  anchor_string: '_1',
+                  anchor_string: 'another test',
                   width: '180',
                   height: '14',
                   anchor_x_offset: '10',
                   anchor_y_offset: '-5',
-                  label: '_1',
+                  label: 'another test',
                   list_items: [
                     {
                       selected: false,


### PR DESCRIPTION
Changes:
- Add `DocusignRest::Client#get_envelope_statuses` to get the statuses of multiple envelopes (useful for polling for changed envelopes)
- Add `DocusignRest::Client#get_documents_from_envelope` to get the document infos from an envelope
- The leading `\r\n` in the multipart_post patch breaks certain other uses of multipart_post, and it doesn't seem to be needed by Docusign any more, so that's been removed
- Tests were broken because Docusign couldn't find `"_1"` in the test PDFs, so the API call failed when it shouldn't have. This replaces that anchor text with `"another test"`, which does appear in the PDFs.
