### PR TITLE
added #get_envelope_audit_events method

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -948,6 +948,28 @@ module DocusignRest
       response
     end
 
+    # Public returns a hash of audit events for a given envelope
+    #
+    # envelope_id       - ID of the envelope to get audit events from
+    #
+    #
+    # Example
+    # client.get_envelope_audit_events(
+    #   envelope_id: "xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx"
+    # )
+    # Returns a hash of the events that have happened to the envelope.
+    def get_envelope_audit_events(options = {})
+      content_type = { 'Content-Type' => 'application/json' }
+      content_type.merge(options[:headers]) if options[:headers]
+
+      uri = build_uri("/accounts/#{acct_id}/envelopes/#{options[:envelope_id]}/audit_events")
+
+      http = initialize_net_http_ssl(uri)
+      request = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
+      response = http.request(request)
+
+      JSON.parse(response.body)
+    end
 
     # Public retrieves the envelope(s) from a specific folder based on search params.
     #


### PR DESCRIPTION
Added another method. This one gets the audit history of an envelope. We needed this functionality in our app.

I'm not sure what your conventions are for placement of methods within client.rb, so I just put it near where my last method is.

Cheers!
