### PR TITLE
adding method that allows getting the raw data of the request and response.

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -6,6 +6,7 @@ module DocusignRest
     # Define the same set of accessors as the DocusignRest module
     attr_accessor *Configuration::VALID_CONFIG_KEYS
     attr_accessor :docusign_authentication_headers, :acct_id
+    attr_accessor :previous_req, :previous_res
 
     def initialize(options={})
       # Merge the config values from the module and those passed to the client.
@@ -37,6 +38,14 @@ module DocusignRest
       # the instance var @account_id because that'll override the attr_accessor
       # that is automatically configured for the configure block
       @acct_id = account_id
+    end
+
+    # Internal: stores the raw request and response on attributes. This is for
+    # those implementations that required to log everything sent and received from
+    # docusign as their process for app certification states
+    def previows_raw_data(request, response)
+      self.previous_res = response
+      self.previous_req = request
     end
 
 
@@ -142,6 +151,8 @@ module DocusignRest
 
       http = initialize_net_http_ssl(uri)
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -612,6 +623,8 @@ module DocusignRest
                 )
 
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -672,6 +685,8 @@ module DocusignRest
                 )
 
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -686,6 +701,8 @@ module DocusignRest
       http = initialize_net_http_ssl(uri)
       request = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -733,6 +750,8 @@ module DocusignRest
       request.body = post_body
 
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -777,6 +796,8 @@ module DocusignRest
       request.body = post_body
 
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -799,6 +820,8 @@ module DocusignRest
       request = Net::HTTP::Post.new(uri.request_uri, headers(content_type))
 
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -834,6 +857,8 @@ module DocusignRest
       request.body = post_body
 
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -862,6 +887,8 @@ module DocusignRest
 
       response = http.request(request)
 
+
+      previows_raw_data(request, response)
       parsed_response = JSON.parse(response.body)
       parsed_response['url']
     end
@@ -889,6 +916,8 @@ module DocusignRest
       http = initialize_net_http_ssl(uri)
       request = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -905,6 +934,8 @@ module DocusignRest
       http = initialize_net_http_ssl(uri)
       request = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -933,6 +964,8 @@ module DocusignRest
       request  = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
       response = http.request(request)
 
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -993,6 +1026,8 @@ module DocusignRest
       request  = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
       response = http.request(request)
 
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -1091,6 +1126,8 @@ module DocusignRest
       request = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
       response = http.request(request)
 
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -1133,6 +1170,8 @@ module DocusignRest
       http = initialize_net_http_ssl(uri)
       request = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -1150,6 +1189,8 @@ module DocusignRest
       request = Net::HTTP::Post.new(uri.request_uri, headers(content_type))
       request.body = post_body
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -1179,6 +1220,8 @@ module DocusignRest
       response = http.request(request)
       json = response.body
       json = '{}' if json.nil? || json == ''
+
+      previows_raw_data(request, response)
       JSON.parse(json)
     end
 
@@ -1195,7 +1238,10 @@ module DocusignRest
 
       http = initialize_net_http_ssl(uri)
       request = Net::HTTP::Get.new(uri.request_uri, headers({ 'Content-Type' => 'application/json' }))
-      JSON.parse(http.request(request).body)
+      response = http.request(request)
+
+      previows_raw_data(request, response)
+      JSON.parse(response.body)
     end
 
 
@@ -1209,7 +1255,10 @@ module DocusignRest
 
       http = initialize_net_http_ssl(uri)
       request = Net::HTTP::Get.new(uri.request_uri, headers({ 'Content-Type' => 'application/json' }))
-      JSON.parse(http.request(request).body)
+      response = http.request(request)
+
+      previows_raw_data(request, response)
+      JSON.parse(response.body)
     end
 
 
@@ -1225,6 +1274,8 @@ module DocusignRest
       http = initialize_net_http_ssl(uri)
       request = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 
@@ -1251,6 +1302,8 @@ module DocusignRest
       request.body = post_body
 
       response = http.request(request)
+
+      previows_raw_data(request, response)
       JSON.parse(response.body)
     end
 


### PR DESCRIPTION
What would be the correct way of accessing the raw request and response data?

I did this, but I wanted to know if there is a cleaner and less obtrusive way.

I want to add this because as for the docusign's documentation, in order to be certified by them, applications using their api must be able of showing response and request logs of each transaction in case a problem arises.

What do you think?
