### PR TITLE
Allow client IDs other than user email for inline signers.

### DIFF
--- a/lib/docusign_rest/version.rb
+++ b/lib/docusign_rest/version.rb
@@ -1,3 +1,3 @@
 module DocusignRest
-  VERSION = "0.2.1.pre"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
I added client ID option selection that matches that used for getting the recipient view URL. They need to match across API calls for the same envelope,
