### PR TITLE
Fixed bug which prevented ability to set a tab's scaleValue

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -399,7 +399,7 @@ module DocusignRest
         end
 
         if options[:sign_here_tab] == true || options[:initial_here_tab] == true
-          tab_hash[:scaleValue] = tab_hash[:scaleValue] || 1
+          tab_hash[:scaleValue] = tab[:scale_value] || 1
         end
 
         tab_hash[:xPosition]  = tab[:x_position] || '0'


### PR DESCRIPTION
I realized that with the current code there was no way to set the scaleValue of a tab, as it was simply referencing itself.
