### PR TITLE
Add logging to api calls

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -1159,7 +1159,10 @@ module DocusignRest
     end
 
     def request_with_logging(http, request, uri, body=nil)
-      JSON.parse(unparsed_request_with_logging(http, request, uri, body))
+      unparsed_response = unparsed_request_with_logging(http, request, uri, body)
+      JSON.parse(unparsed_response)
+    rescue JSON::ParserError => e
+      { 'error_message' => e, 'response' => unparsed_response }
     end
 
     def unparsed_request_with_logging(http, request, uri, body=nil)

--- a/lib/docusign_rest/configuration.rb
+++ b/lib/docusign_rest/configuration.rb
@@ -1,7 +1,9 @@
+require 'logger'
+
 module DocusignRest
   module Configuration
     VALID_CONNECTION_KEYS  = [:endpoint, :api_version, :user_agent, :method].freeze
-    VALID_OPTIONS_KEYS     = [:access_token, :username, :password, :integrator_key, :account_id, :format, :ca_file].freeze
+    VALID_OPTIONS_KEYS     = [:access_token, :username, :password, :integrator_key, :account_id, :format, :ca_file, :logger].freeze
     VALID_CONFIG_KEYS      = VALID_CONNECTION_KEYS + VALID_OPTIONS_KEYS
 
     DEFAULT_ENDPOINT       = 'https://demo.docusign.net/restapi'
@@ -17,6 +19,7 @@ module DocusignRest
     DEFAULT_ACCOUNT_ID     = nil
     DEFAULT_CA_FILE        = nil # often found at: '/etc/ssl/certs/cert.pem'
     DEFAULT_FORMAT         = :json
+    DEFAULT_LOGGER         = Logger.new('/dev/null')
 
     # Build accessor methods for every config options so we can do this, for example:
     #   DocusignRest.format = :xml
@@ -39,6 +42,7 @@ module DocusignRest
       self.account_id     = DEFAULT_ACCOUNT_ID
       self.format         = DEFAULT_FORMAT
       self.ca_file        = DEFAULT_CA_FILE
+      self.logger         = DEFAULT_LOGGER
     end
 
     # Allow configuration via a block

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,6 @@
 require_relative '../lib/docusign_rest'
 require 'minitest/spec'
+require 'minitest/mock'
 require 'minitest/autorun'
 require 'turn'
 require 'json'
@@ -10,5 +11,5 @@ require 'pry'
 VCR.configure do |c|
   c.cassette_library_dir = "test/fixtures/vcr"
   c.hook_into :fakeweb
-  c.default_cassette_options = { record: :all }
+  c.default_cassette_options = { record: :new_episodes }
 end


### PR DESCRIPTION
Log the uri and body (if it exists) for api requests. Log the response status and body.

To use (in rails), do the following in config/initializers/docusign_rest.rb:

``` ruby
config.logger = Rails.logger
```

By default, the logger is set to `Logger.new('/dev/null')`, which just does nothing.

Jon - 

We have been using your gem very successfully for many months now, thanks for taking the time to open source your code.

When we started development on our docusign project, one of the things that docusign asked before they would "certify" us (or whatever they call it) is that we be able to capture the requests we make to them in the event that we report a bug. This PR doesn't fully meet their requirements (because they want the raw http request), but this gets very close, and is very useful for debugging regardless. 

This code is not complete in the sense that there are still a few calls that go unlogged, but hopefully this will be useful despite that, and we can always do the rest of the calls later.  

We only use a couple of calls in our app, so the majority of this changed code has not been tried in production.
