### PR TITLE
Logging

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -1,4 +1,5 @@
 require 'openssl'
+
 module DocusignRest
 
   class Client
@@ -617,6 +618,7 @@ module DocusignRest
       request = initialize_net_http_multipart_post_request(
                   uri, post_body, file_params, headers(options[:headers])
                 )
+
       response = http.request(request)
       generate_log(request, response, uri)
       JSON.parse(response.body)


### PR DESCRIPTION
Another logging variation for your consideration that builds off of the ideas of [miguelperez](https://github.com/miguelperez/docusign_rest/commit/b80d490d70e1ad1f6a6774ed7bddbb1c8ce40711).

This is an attempt to standardize the log format to something that, hopefully, DocuSign will find acceptable for all & doesn't require making sense of the request & response objects.

Basic usage:

```
envelope = connection.create_envelope_from_document(doc)
connection.previous_call_log.each {|line| logger.debug line }
```

While I initially wanted to simply pass the log back in a method call's resulting hash, his approach seemed like the best alternative, as not all methods return a hash.
