### PR TITLE
Fix documentation for get_recipient_view

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,16 +261,17 @@ client = DocusignRest::Client.new
 ```
 
 
-**Retrieving the url for embedded signing. (Returns a string, not a hash)**
+**Retrieving the url for embedded signing**
 
 ```ruby
 client = DocusignRest::Client.new
-@url = client.get_recipient_view(
+response = client.get_recipient_view(
   envelope_id: @envelope_response["envelopeId"],
   name: current_user.full_name,
   email: current_user.email,
   return_url: 'http://google.com'
 )
+puts response["url"]
 ```
 
 

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -823,7 +823,7 @@ module DocusignRest
     # headers     - optional hash of headers to merge into the existing
     #               required headers for a multipart request.
     #
-    # Returns the URL string for embedded signing (can be put in an iFrame)
+    # Returns a hash with the URL for embedded signing (can be put in an iFrame)
     def get_recipient_view(options={})
       content_type = { 'Content-Type' => 'application/json' }
       content_type.merge(options[:headers]) if options[:headers]


### PR DESCRIPTION
`Client#get_recipient_view` returns a Hash, not a String. 

It previously returned a String, but was changed in this commit to return a Hash: https://github.com/jondkinney/docusign_rest/commit/6646929d172249d0b3b99b5a441a4753f2044a52
However, the Readme/comment still says it returns a string.