### PR TITLE
Fix X / Y position flags in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ document_envelope_response = client.create_envelope_from_document(
       sign_here_tabs: [
         {
           anchor_string: 'sign_here_1',
-          anchor_x_offset: '140',
-          anchor_y_offset: '8'
+          x_position: '140',
+          y_position: '8'
         }
       ]
     },
@@ -126,13 +126,13 @@ document_envelope_response = client.create_envelope_from_document(
       sign_here_tabs: [
         {
           anchor_string: 'sign_here_2',
-          anchor_x_offset: '140',
-          anchor_y_offset: '8'
+          x_position: '140',
+          y_position: '8'
         },
         {
           anchor_string: 'sign_here_3',
-          anchor_x_offset: '140',
-          anchor_y_offset: '8'
+          x_position: '140',
+          y_position: '8'
         }
       ]
     }
@@ -162,8 +162,8 @@ client = DocusignRest::Client.new
       sign_here_tabs: [
         {
           anchor_string: 'issuer_sig',
-          anchor_x_offset: '140',
-          anchor_y_offset: '8'
+          x_position: '140',
+          y_position: '8'
         }
       ]
     },
@@ -175,8 +175,8 @@ client = DocusignRest::Client.new
       sign_here_tabs: [
         {
           anchor_string: 'attorney_sig',
-          anchor_x_offset: '140',
-          anchor_y_offset: '8'
+          x_position: '140',
+          y_position: '8'
         }
       ]
     }


### PR DESCRIPTION
I tried to use the code included in the README to put together a
quick POC app and noticed the "anchor_x_offset" and
"anchor_y_offset" flags didn't seem to change the location of the
signature, always ending up in the upper-right hand corner.

After some digging, I found that the client.rb expects this data to
be passed in as "x_position" and "y_position".  After updating the
POC to use these keys, the signature would move around as expected.

I've updated the documentation to include the correct data flags.
This should allow new users to get up to speed a lot quicker, without
having to alter a local copy of the library to find the right flags.
