### PR TITLE
Add get_folder_list client method/request

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -1105,6 +1105,18 @@ module DocusignRest
       JSON.parse(response.body)
     end
 
+    # Public retrieves folder information. Helpful to use before client.search_folder_for_envelopes
+    def get_folder_list(options={})
+      content_type = { 'Content-Type' => 'application/json' }
+      content_type.merge(options[:headers]) if options[:headers]
+
+      uri = build_uri("/accounts/#{@acct_id}/folders/")
+
+      http = initialize_net_http_ssl(uri)
+      request = Net::HTTP::Get.new(uri.request_uri, headers(content_type))
+      response = http.request(request)
+      JSON.parse(response.body)
+    end
 
     # Public retrieves the envelope(s) from a specific folder based on search params.
     #


### PR DESCRIPTION
Adds a method to quickly execute [Get Folder List](https://www.docusign.com/p/RESTAPIGuide/RESTAPIGuide.htm#REST API References/Get Folder List.htm%3FTocPath%3DREST%2520API%2520References%7C_____96) request.
