### PR TITLE
Added routing order to signers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ document_envelope_response = client.create_envelope_from_document(
       name: 'Test Guy',
       email: 'someone@gmail.com',
       role_name: 'Issuer',
+      routing_order: 1,
       sign_here_tabs: [
         {
           anchor_string: 'sign_here_1',
@@ -123,6 +124,7 @@ document_envelope_response = client.create_envelope_from_document(
       name: 'Test Girl',
       email: 'someone+else@gmail.com',
       role_name: 'Attorney',
+      routing_order: 2,
       sign_here_tabs: [
         {
           anchor_string: 'sign_here_2',
@@ -159,6 +161,7 @@ client = DocusignRest::Client.new
       name: 'jon',
       email: 'someone@gmail.com',
       role_name: 'Issuer',
+      routing_order: 1,
       sign_here_tabs: [
         {
           anchor_string: 'issuer_sig',
@@ -172,6 +175,7 @@ client = DocusignRest::Client.new
       name: 'tim',
       email: 'someone+else@gmail.com',
       role_name: 'Attorney',
+      routing_order: 2,
       sign_here_tabs: [
         {
           anchor_string: 'attorney_sig',
@@ -204,13 +208,15 @@ client = DocusignRest::Client.new
       embedded: true,
       name: 'jon',
       email: 'someone@gmail.com',
-      role_name: 'Issuer'
+      role_name: 'Issuer',
+      routing_order: 1
     },
     {
       embedded: true,
       name: 'tim',
       email: 'someone+else@gmail.com',
-      role_name: 'Attorney'
+      role_name: 'Attorney',
+      routing_order: 2
     }
   ]
 )
@@ -235,6 +241,7 @@ client = DocusignRest::Client.new
       name: 'jon',
       email: 'someone@gmail.com',
       role_name: 'Issuer',
+      routing_order: 1,
       text_tabs: [
         { 
           label: 'Seller Full Name', 
@@ -248,6 +255,7 @@ client = DocusignRest::Client.new
       name: 'tim',
       email: 'someone+else@gmail.com',
       role_name: 'Attorney',
+      routing_order: 2,
       text_tabs: [
         { 
           label: 'Attorney Full Name', 

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -289,6 +289,7 @@ module DocusignRest
     #                      the clientUserId value to the signer's email.
     # email_notification - Send an email or not
     # role_name          - The signer's role, like 'Attorney' or 'Client', etc.
+    # routing_order      - The signer's routing order(signing order)
     # template_locked    - Doesn't seem to work/do anything
     # template_required  - Doesn't seem to work/do anything
     # anchor_string      - The string of text to anchor the 'sign here' tab to

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -322,7 +322,7 @@ module DocusignRest
           recipientId:                           "#{index + 1}",
           requireIdLookup:                       false,
           roleName:                              signer[:role_name],
-          routingOrder:                          index + 1,
+          routingOrder:                          signer[:routing_order] || index + 1,
           socialAuthentications:                 nil
         }
 


### PR DESCRIPTION
You can now set order in which signers will have access to sign the document.
