### PR TITLE
Fix Content-Type Header

### DIFF
--- a/examples/request_via_raw_net_http.rb
+++ b/examples/request_via_raw_net_http.rb
@@ -61,7 +61,7 @@ docusign_headers = %{
 
 headers = {
   'X-DocuSign-Authentication' => "#{docusign_headers}",
-  'Content-Type'              => "multipart/form-data, boundary=#{BOUNDARY}",
+  'Content-Type'              => "multipart/form-data; boundary=#{BOUNDARY}",
   'Accept'                    => 'application/json',
   'Content-Length'            => "#{post_body.length}"
 }


### PR DESCRIPTION
multipart/form-data and boundary must be separated by a semicolon.
