### PR TITLE
Expand composite template creation

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -509,10 +509,15 @@ module DocusignRest
       composite_array = []
       index = 0
       server_template_ids.each  do |template_id|
-        server_template_hash = Hash[:sequence, index += 1, \
-          :templateId, template_id]
-        templates_hash = Hash[:serverTemplates, [server_template_hash], \
-          :inlineTemplates,  get_inline_signers(signers, index += 1)]
+        sequence = (index += 1).to_s
+        server_template_hash = {
+            sequence: sequence,
+            templateId: template_id
+        }
+        templates_hash = {
+          serverTemplates: [server_template_hash],
+          inlineTemplates: get_inline_signers(signers, sequence)
+        }
         composite_array << templates_hash
       end
       composite_array
@@ -531,7 +536,7 @@ module DocusignRest
           :clientUserId, signer[:client_id] || signer[:email]]
         signers_array << signers_hash
       end
-      template_hash = Hash[:sequence, sequence, :recipients, { signers: signers_array }]
+      template_hash = {sequence: sequence, recipients: { signers: signers_array }}
       [template_hash]
     end
 

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -531,9 +531,20 @@ module DocusignRest
     def get_inline_signers(signers, sequence)
       signers_array = []
       signers.each do |signer|
-        signers_hash = Hash[:email, signer[:email], :name, signer[:name], \
-          :recipientId, signer[:recipient_id], :roleName, signer[:role_name], \
-          :clientUserId, signer[:client_id] || signer[:email]]
+        signers_hash = {
+          email: signer[:email],
+          name: signer[:name],
+          recipientId: signer[:recipient_id],
+          roleName: signer[:role_name],
+          clientUserId: signer[:client_id] || signer[:email],
+          tabs: {
+            textTabs:     get_signer_tabs(signer[:text_tabs]),
+            checkboxTabs: get_signer_tabs(signer[:checkbox_tabs]),
+            numberTabs:   get_signer_tabs(signer[:number_tabs]),
+            fullNameTabs: get_signer_tabs(signer[:fullname_tabs]),
+            dateTabs:     get_signer_tabs(signer[:date_tabs])
+          }
+        }
         signers_array << signers_hash
       end
       template_hash = {sequence: sequence, recipients: { signers: signers_array }}

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -777,6 +777,8 @@ module DocusignRest
 
       post_body = {
         status:             options[:status],
+        emailBlurb:         options[:email][:body],
+        emailSubject:       options[:email][:subject],
         compositeTemplates: get_composite_template(options[:server_template_ids], options[:signers])
       }.to_json
 


### PR DESCRIPTION
Expanded functionality for composite templates. Can now pass email body, email subject, and the same commonly used tabs that you can pass when creating an envelope from an individual template. 