### PR TITLE
Add event notification to create envelope from document

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -612,6 +612,7 @@ module DocusignRest
         recipients: {
           signers: get_signers(options[:signers])
         },
+        eventNotification:  get_event_notification(options[:event_notification]),
         status: "#{options[:status]}",
         customFields: options[:custom_fields]
       }.to_json


### PR DESCRIPTION
# What this PR does ?

This PR adds the ability to get event notifications from `create_envelope_from_document`.
As we did for `create_envelope_from_template` just [here](https://github.com/jondkinney/docusign_rest/blob/master/lib/docusign_rest/client.rb#L737).

# Why ?

I would like to use this feature when generating an envelope from a document and I think this should be possible for any `create_envelope_from*` method.

Mind to 👀 @jondkinney 