### PR TITLE
Add parameter support to combined document

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -1037,6 +1037,7 @@ module DocusignRest
       content_type.merge(options[:headers]) if options[:headers]
 
       uri = build_uri("/accounts/#{acct_id}/envelopes/#{options[:envelope_id]}/documents/combined")
+      uri.query = URI.encode_www_form(options[:params]) if options[:params] 
 
       http = initialize_net_http_ssl(uri)
       request = Net::HTTP::Get.new(uri.request_uri, headers(content_type))


### PR DESCRIPTION
Combined document allows for optional parameters that we wanted to take advantage of. 

https://www.docusign.com/p/RESTAPIGuide/Content/REST%20API%20References/Get%20Envelope%20Documents%20and%20Certificate.htm