### PR TITLE
Enable requireSignOnPaper option for a composite template recipient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add envelopeIds option to DocusignRest::Client#get_envelope_statuses (Amit Chakradeo)
 * Add recipientEvents option to event notification payload (Guillermo Wu)
 * Added logging of each call to support Docusign API certification (Jon Witucki)
+* Enable requireSignOnPaper option for a recipient in a composite template (Tom Copeland)
 * Support routingOrder option when generating signers (Guillaume Dott)
 * Support arbitrary parameters to DocusignRest::Client#get_combined_document_from_envelope (Coley Brown)
 * Support event notifications in DocusignRest::Client#get_combined_document_from_envelope (Maxime Orefice)
@@ -18,6 +19,7 @@
 ### Misc:
 * Replace monkeypatch with argument usage (Jean-Philippe Moal)
 * Bumped minimum Ruby version to 2.1.0. (Tom Copeland)
+* DocusignRest::Client#void_envelope now returns a JSON object rather than a request object (Tom Copeland)
 
 ## v0.2.0 April 28 2017
 

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -640,6 +640,7 @@ module DocusignRest
           recipientId: signer[:recipient_id],
           roleName: signer[:role_name],
           clientUserId: signer[:client_id] || signer[:email],
+          requireSignOnPaper: signer[:require_sign_on_paper] || false,
           tabs: {
             textTabs:     get_signer_tabs(signer[:text_tabs]),
             checkboxTabs: get_signer_tabs(signer[:checkbox_tabs]),
@@ -864,6 +865,7 @@ module DocusignRest
         emailBlurb:         options[:email][:body],
         emailSubject:       options[:email][:subject],
         templateId:         options[:template_id],
+        enableWetSign:      options[:wet_sign],
         brandId:            options[:brand_id],
         eventNotification:  get_event_notification(options[:event_notification]),
         templateRoles:      get_template_roles(options[:signers]),
@@ -894,10 +896,8 @@ module DocusignRest
     # email/body            - Sets the text in the email body
     # email/subject         - Sets the text in the email subject line
     # files                 - Sets documents to be used instead of inline or server templates
-    # template_roles        - See the get_template_roles method definition for a list
-    #                         of options to pass. Note: for consistency sake we call
-    #                         this 'signers' and not 'templateRoles' when we build up
-    #                         the request in client code.
+    # signers               - See get_template_roles/get_inline_signers for a list
+    #                         of options to pass.
     # headers               - Optional hash of headers to merge into the existing
     #                         required headers for a multipart request.
     # server_template_ids   - Array of ids for templates uploaded to DocuSign. Templates


### PR DESCRIPTION
Note that a composite template is required for this functionality, and
this feature also needs to be enabled in your docusign account.