### PR TITLE
Handle logging of PDF docs

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -1971,7 +1971,15 @@ module DocusignRest
       request.each_capitalized{ |k,v| log << "#{k}: #{v.gsub(/(?<="Password":")(.+?)(?=")/, '[FILTERED]')}" }
       # Trims out the actual binary file to reduce log size
       if request.body
-        request_body = request.body.gsub(/(?<=Content-Transfer-Encoding: binary).+?(?=-------------RubyMultipartPost)/m, "\n[BINARY BLOB]\n")
+        request_body = begin
+          request.body.gsub(/(?<=Content-Transfer-Encoding: binary).+?(?=-------------RubyMultipartPost)/m, "\n[BINARY BLOB]\n")
+        rescue ArgumentError => ae
+          if ae.message == "invalid byte sequence in UTF-8"
+            request.body.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').gsub(/^%PDF.*%%EOF/m, "\n[PDF BLOB]\n")
+          else
+            raise
+          end
+        end
         log << "Body: #{request_body}"
       end
       log << '--DocuSign RESPONSE--'


### PR DESCRIPTION
Adding a PDF document to an existing envelope could result in invalid
UTF-8 being passed to the logging method.  But that's ok, we just want
to handle it since we'll elide it anyway.