### PR TITLE
Enable requireSignOnPaper option for non-template envelopes

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -352,6 +352,7 @@ module DocusignRest
           phoneAuthentication:                   nil,
           recipientAttachment:                   nil,
           requireIdLookup:                       signer[:require_id_lookup],
+          requireSignOnPaper:                    signer[:require_sign_on_paper] || false,
           roleName:                              signer[:role_name],
           routingOrder:                          signer[:routing_order] || index + 1,
           socialAuthentications:                 nil


### PR DESCRIPTION
Fixes  #124 

This copies the same approach from `get_inline_signers`. @jondkinney or @tcopeland I took the liberty to make the PR since it was rather small. I'm _pretty sure_ it's legit to pass this option when creating a non-template envelope but my DocuSign experience is still pretty limited so I obviously defer to your insights.