### PR TITLE
Allow to assign accessCode to signers

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -402,7 +402,7 @@ module DocusignRest
           checkboxTabs:         get_tabs(signer[:checkbox_tabs], options, index),
           companyTabs:          nil,
           dateSignedTabs:       get_tabs(signer[:date_signed_tabs], options, index),
-          dateTabs:             nil,
+          dateTabs:             get_tabs(signer[:date_tabs], options, index),
           declineTabs:          nil,
           emailTabs:            get_tabs(signer[:email_tabs], options, index),
           envelopeIdTabs:       nil,
@@ -640,7 +640,7 @@ module DocusignRest
         server_template_hash = {
             sequence: (idx+1).to_s,
             templateId: template_id,
-            templateRoles: get_template_roles(signers),
+            templateRoles: get_signers(signers),
         }
         templates_hash = {
           serverTemplates: [server_template_hash],
@@ -911,7 +911,7 @@ module DocusignRest
         enableWetSign:      options[:wet_sign],
         brandId:            options[:brand_id],
         eventNotification:  get_event_notification(options[:event_notification]),
-        templateRoles:      get_template_roles(options[:signers]),
+        templateRoles:      get_signers(options[:signers]),
         customFields:       options[:custom_fields],
         allowReassign:      options[:allow_reassign]
       }.to_json

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -228,6 +228,7 @@ module DocusignRest
           name:     signer[:name],
           email:    signer[:email],
           roleName: signer[:role_name],
+          accessCode: signer[:access_code],
           tabs: {
             textTabs:     get_signer_tabs(signer[:text_tabs]),
             checkboxTabs: get_signer_tabs(signer[:checkbox_tabs]),

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -343,7 +343,7 @@ module DocusignRest
 
       signers.each_with_index do |signer, index|
         doc_signer = {
-          accessCode:                            '',
+          accessCode:                            signer[:access_code],
           addAccessCodeToEmail:                  false,
           customFields:                          signer[:custom_fields],
           idCheckConfigurationName:              signer[:id_check_configuration_name],

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -402,7 +402,7 @@ module DocusignRest
           checkboxTabs:         get_tabs(signer[:checkbox_tabs], options, index),
           companyTabs:          nil,
           dateSignedTabs:       get_tabs(signer[:date_signed_tabs], options, index),
-          dateTabs:             get_tabs(signer[:date_tabs], options, index),
+          dateTabs:             nil,
           declineTabs:          nil,
           emailTabs:            get_tabs(signer[:email_tabs], options, index),
           envelopeIdTabs:       nil,
@@ -640,7 +640,7 @@ module DocusignRest
         server_template_hash = {
             sequence: (idx+1).to_s,
             templateId: template_id,
-            templateRoles: get_signers(signers),
+            templateRoles: get_template_roles(signers),
         }
         templates_hash = {
           serverTemplates: [server_template_hash],
@@ -911,7 +911,7 @@ module DocusignRest
         enableWetSign:      options[:wet_sign],
         brandId:            options[:brand_id],
         eventNotification:  get_event_notification(options[:event_notification]),
-        templateRoles:      get_signers(options[:signers]),
+        templateRoles:      get_template_roles(options[:signers]),
         customFields:       options[:custom_fields],
         allowReassign:      options[:allow_reassign]
       }.to_json


### PR DESCRIPTION
This allows to specify an access_code to an envelope via signers parameters.
See: https://support.docusign.com/en/guides/ndse-user-guide-access-code