### PR TITLE
Do not assign `clientuserId` unless embedded

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -670,7 +670,6 @@ module DocusignRest
           name: signer[:name],
           recipientId: signer[:recipient_id],
           roleName: signer[:role_name],
-          clientUserId: signer[:client_id] || signer[:email],
           requireSignOnPaper: signer[:require_sign_on_paper] || false,
           tabs: {
             textTabs:       get_signer_tabs(signer[:text_tabs]),
@@ -682,6 +681,9 @@ module DocusignRest
             signHereTabs:   get_sign_here_tabs(signer[:sign_here_tabs])
           }
         }
+        if signer[:embedded]
+          signers_hash[:clientUserId] = signer[:client_id] || signer[:email]
+        end
         signers_array << signers_hash
       end
       template_hash = {sequence: sequence, recipients: { signers: signers_array }}


### PR DESCRIPTION
Previously this defaulted to always including the `clientuserId` in the request. At which point DocuSign thinks this document is to be signed embedded and will not send a notification to the signer via email. By only setting it if the the embedded key is provided we can use this in both instances and still send emails to signers who need to be notified.