### PR TITLE
allow to set recipient_id and routing_order for carbon copies

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -441,7 +441,7 @@ module DocusignRest
         (options || []).each do |cc|
           signer_count += 1
           raise "Missing required data [:email, :name]" unless (cc[:email] && cc[:name])
-          cc.merge!(recipient_id: signer_count, routing_order: signer_count)
+          cc.reverse_merge!(recipient_id: signer_count, routing_order: signer_count)
           copies << camelize_keys(cc)
         end
       copies


### PR DESCRIPTION
So routing order can be set for both signers and carbon copies